### PR TITLE
Fix #9

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.14.11
 
 # Mod Properties
-	mod_version = 1.2.1
+	mod_version = 1.2.2
 	maven_group = com.provismet
 	archives_base_name = tooltip-scroll
 

--- a/src/main/java/com/provismet/tooltipscroll/ScrollTracker.java
+++ b/src/main/java/com/provismet/tooltipscroll/ScrollTracker.java
@@ -49,6 +49,7 @@ public class ScrollTracker {
         for (int i = 0; i < item1.size(); ++i) {
             if (item1.get(i) instanceof OrderedTextTooltipComponent && !(item2.get(i) instanceof OrderedTextTooltipComponent)) return false;
             if (item2.get(i) instanceof OrderedTextTooltipComponent && !(item1.get(i) instanceof OrderedTextTooltipComponent)) return false;
+            if (!(item1.get(i) instanceof OrderedTextTooltipComponent) && !(item2.get(i) instanceof OrderedTextTooltipComponent)) continue; // Can't compare non-text.
             
             OrderedTextTooltipComponentAccessor accessible1 = (OrderedTextTooltipComponentAccessor)((OrderedTextTooltipComponent)item1.get(i));
             OrderedTextTooltipComponentAccessor accessible2 = (OrderedTextTooltipComponentAccessor)((OrderedTextTooltipComponent)item2.get(i));


### PR DESCRIPTION
Equality check will now be skipped if both tooltip components are not text components.