### PR TITLE
start on top feature (port from 1.21.6 to 1.21.10)

### DIFF
--- a/src/main/java/com/provismet/tooltipscroll/Options.java
+++ b/src/main/java/com/provismet/tooltipscroll/Options.java
@@ -11,6 +11,7 @@ import java.io.FileWriter;
 public abstract class Options {
     public static boolean canScroll = true;
     public static boolean useWASD = false;
+    public static boolean startOnTop = false;
     public static boolean resetOnUnlock = true;
     public static boolean useLShift = true;
     public static boolean invertXScroll = false;
@@ -18,6 +19,7 @@ public abstract class Options {
 
     public static final String CAN_SCROLL = "canScroll";
     public static final String USE_WASD = "useWASD";
+    public static final String START_ON_TOP = "startOnTop";
     public static final String RESET_ON_UNLOCK = "resetOnUnlock";
     public static final String USE_LEFT_SHIFT = "useLShift";
     public static final String INVERT_X_SCROLL = "invertXScroll";
@@ -30,6 +32,7 @@ public abstract class Options {
         String json = new JsonBuilder()
             .append(CAN_SCROLL, canScroll)
             .append(USE_WASD, useWASD)
+            .append(START_ON_TOP, startOnTop)
             .append(RESET_ON_UNLOCK, resetOnUnlock)
             .append(USE_LEFT_SHIFT, useLShift)
             .append(INVERT_X_SCROLL, invertXScroll)
@@ -53,6 +56,7 @@ public abstract class Options {
             if (reader != null) {
                 reader.getBoolean(CAN_SCROLL).ifPresent(val -> canScroll = val);
                 reader.getBoolean(USE_WASD).ifPresent(val -> useWASD = val);
+                reader.getBoolean(START_ON_TOP).ifPresent(val -> startOnTop = val);
                 reader.getBoolean(RESET_ON_UNLOCK).ifPresent(val -> resetOnUnlock = val);
                 reader.getBoolean(USE_LEFT_SHIFT).ifPresent(val -> useLShift = val);
                 reader.getBoolean(INVERT_X_SCROLL).ifPresent(val -> invertXScroll = val);

--- a/src/main/java/com/provismet/tooltipscroll/ScrollTracker.java
+++ b/src/main/java/com/provismet/tooltipscroll/ScrollTracker.java
@@ -22,6 +22,8 @@ public class ScrollTracker {
 
     private static double trueXOffset = 0;
     private static double trueYOffset = 0;
+
+		private static boolean moved = false;
     
     // save the currently selected item, the scroll offset will reset if the user hovers over a different item
     private static List<TooltipComponent> currentItem;
@@ -94,36 +96,49 @@ public class ScrollTracker {
         return MathHelper.floor(convenientInjectionPoint.doubleValue());
     }
 
+		public static void setInitialYOffset(int offset) {
+				trueYOffset += offset;
+				currentYOffset = trueYOffset;
+		}
+
     public static void scrollUp () {
         scrollUp(scrollSize);
+				moved = true;
     }
 
     public static void scrollUp (int amount) {
         if (!isLocked()) trueYOffset -= amount;
+				moved = true;
     }
 
     public static void scrollDown () {
         scrollDown(scrollSize);
+				moved = true;
     }
 
     public static void scrollDown (int amount) {
         if (!isLocked()) trueYOffset += amount;
+				moved = true;
     }
 
     public static void scrollLeft () {
         scrollLeft(scrollSize);
+				moved = true;
     }
 
     public static void scrollLeft (int amount) {
         if (!isLocked()) trueXOffset -= amount;
+				moved = true;
     } 
 
     public static void scrollRight () {
         scrollRight(scrollSize);
+				moved = true;
     }
 
     public static void scrollRight (int amount) {
         if (!isLocked()) trueXOffset += amount;
+				moved = true;
     }
 
     private static void resetScroll () {
@@ -131,6 +146,7 @@ public class ScrollTracker {
         currentYOffset = 0;
         trueXOffset = 0;
         trueYOffset = 0;
+				moved = false;
     }
 
     private static boolean isEqual (List<TooltipComponent> item1, List<TooltipComponent> item2) {
@@ -175,4 +191,8 @@ public class ScrollTracker {
         }
         unlockTime = System.currentTimeMillis();
     }
+
+		public static boolean hasMoved() {
+				return moved;
+		}
 }

--- a/src/main/java/com/provismet/tooltipscroll/config/TooltipConfig.java
+++ b/src/main/java/com/provismet/tooltipscroll/config/TooltipConfig.java
@@ -30,6 +30,12 @@ public class TooltipConfig {
             .setTooltip(Text.translatable("entrytooltip.tooltipscroll.usewasd"))
             .setSaveConsumer(newValue -> Options.useWASD = newValue)
             .build());
+
+        general.addEntry(entryBuilder.startBooleanToggle(Text.translatable("entry.tooltipscroll.startontop"), Options.startOnTop)
+            .setDefaultValue(false)
+            .setTooltip(Text.translatable("entrytooltip.tooltipscroll.startontop"))
+            .setSaveConsumer(newValue -> Options.startOnTop = newValue)
+            .build());
         
         general.addEntry(entryBuilder.startBooleanToggle(Text.translatable("entry.tooltipscroll.resetonunlock"), Options.resetOnUnlock)
             .setDefaultValue(true)

--- a/src/main/java/com/provismet/tooltipscroll/mixin/DrawContextMixin.java
+++ b/src/main/java/com/provismet/tooltipscroll/mixin/DrawContextMixin.java
@@ -3,6 +3,7 @@ package com.provismet.tooltipscroll.mixin;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.llamalad7.mixinextras.sugar.ref.LocalIntRef;
 import com.provismet.tooltipscroll.ScrollTracker;
+import com.provismet.tooltipscroll.Options;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.tooltip.TooltipComponent;
@@ -38,7 +39,7 @@ public abstract class DrawContextMixin {
 		effectiveX.set(effectiveX.get() + ScrollTracker.getXOffset());
 		effectiveY.set(effectiveY.get() + ScrollTracker.getYOffset());
 
-    if (!ScrollTracker.hasMoved()) {
+    if (Options.startOnTop && !ScrollTracker.hasMoved()) {
 			int originalY = effectiveY.get();
 			if (effectiveY.get() < 4) {
 				effectiveY.set(4);

--- a/src/main/java/com/provismet/tooltipscroll/mixin/DrawContextMixin.java
+++ b/src/main/java/com/provismet/tooltipscroll/mixin/DrawContextMixin.java
@@ -30,9 +30,20 @@ public abstract class DrawContextMixin {
 		ScrollTracker.setItem(components);
 	}
 
-	@Inject(method = "drawTooltipImmediately", at = @At(value = "INVOKE", target = "Lorg/joml/Matrix3x2fStack;pushMatrix()Lorg/joml/Matrix3x2fStack;"))
+	@Inject(
+			method = "drawTooltipImmediately",
+			at = @At(value = "INVOKE", target = "Lorg/joml/Matrix3x2fStack;pushMatrix()Lorg/joml/Matrix3x2fStack;")
+	)
 	private void editXY (TextRenderer textRenderer, List<TooltipComponent> components, int x, int y, TooltipPositioner positioner, @Nullable Identifier texture, CallbackInfo info, @Local(ordinal = 6) LocalIntRef effectiveX, @Local(ordinal = 7) LocalIntRef effectiveY) {
 		effectiveX.set(effectiveX.get() + ScrollTracker.getXOffset());
 		effectiveY.set(effectiveY.get() + ScrollTracker.getYOffset());
+
+    if (!ScrollTracker.hasMoved()) {
+			int originalY = effectiveY.get();
+			if (effectiveY.get() < 4) {
+				effectiveY.set(4);
+				ScrollTracker.setInitialYOffset(4 - originalY);
+			}
+    }
 	}
 }

--- a/src/main/resources/assets/toolscroll/lang/en_us.json
+++ b/src/main/resources/assets/toolscroll/lang/en_us.json
@@ -7,6 +7,7 @@
 
     "entry.tooltipscroll.canscroll": "Enable ScrollWheel",
     "entry.tooltipscroll.usewasd": "Enable WASD",
+    "entry.tooltipscroll.startontop": "Start On Top",
     "entry.tooltipscroll.resetonunlock": "Reset Position When Not Hovered",
     "entry.tooltipscroll.uselshift": "Use Left-Shift",
     "entry.tooltipscroll.invertxscroll": "Invert Horizontal Movement",
@@ -17,6 +18,7 @@
 
     "entrytooltip.tooltipscroll.canscroll": "Allows the scroll wheel to move a tooltip.",
     "entrytooltip.tooltipscroll.usewasd": "Allows the WASD keys to move a tooltip.",
+    "entrytooltip.tooltipscroll.startontop": "Start at the top of the tooltip when hovered (if off-screen)",
     "entrytooltip.tooltipscroll.resetonunlock": "Resets the position of a tooltip when it is not visible.",
     "entrytooltip.tooltipscroll.uselshift": "Use left-shift for horizontal scrolling. (unaffected by keybind)",
     "entrytooltip.tooltipscroll.invertxscroll": "Invert the horizontal tooltip movement when scrolling.",


### PR DESCRIPTION
**This pr ports the “start on top” feature from 1.21.6 and is a copy of pr #33.**
No changes, everything has been tested.

Option that allows a tooltip to appear at the top when the cursor is hovered over item if it extends beyond the screen.\
\- Closes #32.\
\- Disabled by default.\
\- No translations (English only).\
<img width="988" height="511" alt="startOnTop" src="https://github.com/user-attachments/assets/ff5fd9ee-77ae-4ed0-a64e-177742343ebf" />
