### PR TITLE
Added feature to disable scrolling chat while a tooltip is visible.

### DIFF
--- a/src/main/java/com/provismet/tooltipscroll/Options.java
+++ b/src/main/java/com/provismet/tooltipscroll/Options.java
@@ -17,6 +17,7 @@ public abstract class Options {
     public static boolean invertXScroll = false;
     public static boolean invertYScroll = false;
     public static boolean matrixMode = false;
+    public static boolean disableChatScroll = false;
 
     private static final String CAN_SCROLL = "canScroll";
     private static final String USE_WASD = "useWASD";
@@ -29,6 +30,7 @@ public abstract class Options {
     private static final String SCROLL_SPEED_KEYBOARD = "keyboardScrollSpeed";
     private static final String SMOOTHNESS = "scrollSmoothness";
     private static final String MATRIX_COMPAT = "matrixCompatibilityMode";
+    public static final String DISABLE_CHAT_SCROLL ="disableChatScroll";
 
     public static void saveJSON () {
         String json = new JsonBuilder()
@@ -43,6 +45,7 @@ public abstract class Options {
             .append(SCROLL_SPEED_KEYBOARD, ScrollTracker.scrollSizeKeyboard)
             .append(SMOOTHNESS, ScrollTracker.smoothnessModifier)
             .append(MATRIX_COMPAT, matrixMode)
+            .append(DISABLE_CHAT_SCROLL, disableChatScroll)
             .toString();
 
         try (FileWriter writer = new FileWriter("config/tooltipscroll.json")) {
@@ -68,6 +71,7 @@ public abstract class Options {
                 reader.getInteger(SCROLL_SPEED_KEYBOARD).ifPresent(val -> ScrollTracker.scrollSizeKeyboard = Math.max(1, val));
                 reader.getDouble(SMOOTHNESS).ifPresent(val -> ScrollTracker.smoothnessModifier = MathHelper.clamp(val, 0.05, 1.0));
                 reader.getBoolean(MATRIX_COMPAT).ifPresent(val -> matrixMode = val);
+                reader.getBoolean(DISABLE_CHAT_SCROLL).ifPresent(val -> disableChatScroll = val);
             }
         }
         catch (FileNotFoundException e) {

--- a/src/main/java/com/provismet/tooltipscroll/ScrollTracker.java
+++ b/src/main/java/com/provismet/tooltipscroll/ScrollTracker.java
@@ -23,7 +23,8 @@ public class ScrollTracker {
     private static double trueYOffset = 0;
 
 		private static boolean moved = false;
-    
+
+    private static boolean tooltipShown = false;
     // save the currently selected item, the scroll offset will reset if the user hovers over a different item
     private static List<TooltipComponent> currentItem;
 
@@ -191,6 +192,13 @@ public class ScrollTracker {
         unlockTime = System.currentTimeMillis();
     }
 
+    public static void setTooltipShown(boolean state){
+        tooltipShown = state;
+    }
+    
+    public static boolean isTooltipShown(){
+        return tooltipShown;
+    }
 		public static boolean hasMoved() {
 				return moved;
 		}

--- a/src/main/java/com/provismet/tooltipscroll/config/TooltipConfig.java
+++ b/src/main/java/com/provismet/tooltipscroll/config/TooltipConfig.java
@@ -88,6 +88,12 @@ public class TooltipConfig {
             .setSaveConsumer(val -> Options.matrixMode = val)
             .build());
 
+        general.addEntry(entryBuilder.startBooleanToggle(Text.translatable("entry.tooltipscroll.disablechatscroll"), Options.disableChatScroll)
+                .setDefaultValue(false)
+                .setTooltip(Text.translatable("entrytooltip.tooltipscroll.disablechatscroll"))
+                .setSaveConsumer(val -> Options.disableChatScroll = val)
+                .build());
+
         builder.setSavingRunnable(Options::saveJSON);
         return builder.build();
     }

--- a/src/main/java/com/provismet/tooltipscroll/mixin/ChatMixin.java
+++ b/src/main/java/com/provismet/tooltipscroll/mixin/ChatMixin.java
@@ -1,0 +1,22 @@
+package com.provismet.tooltipscroll.mixin;
+
+import com.provismet.tooltipscroll.Options;
+import com.provismet.tooltipscroll.ScrollTracker;
+import com.provismet.tooltipscroll.TooltipScrollClient;
+import net.minecraft.client.gui.screen.ChatScreen;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ChatScreen.class)
+public class ChatMixin {
+    @Inject(method = "mouseScrolled", at = @At("HEAD"), cancellable = true)
+    private void mouseScrolled(double mouseX, double mouseY, double horizontalAmount, double verticalAmount, CallbackInfoReturnable<Boolean> info) {
+        if(Options.disableChatScroll) {
+            if(ScrollTracker.isTooltipShown()){
+                info.cancel();
+            }
+        }
+    }
+}

--- a/src/main/java/com/provismet/tooltipscroll/mixin/DrawContextMixin.java
+++ b/src/main/java/com/provismet/tooltipscroll/mixin/DrawContextMixin.java
@@ -62,6 +62,7 @@ public abstract class DrawContextMixin {
         at = @At("HEAD")
     )
     private void headMatrices(TextRenderer textRenderer, List<TooltipComponent> components, int x, int y, TooltipPositioner positioner, Identifier texture, CallbackInfo info) {
+        ScrollTracker.setTooltipShown(true);
         if (!Options.matrixMode) return;
 
         this.matrices.pushMatrix();

--- a/src/main/java/com/provismet/tooltipscroll/mixin/ScreenMixin.java
+++ b/src/main/java/com/provismet/tooltipscroll/mixin/ScreenMixin.java
@@ -17,4 +17,10 @@ public abstract class ScreenMixin {
 	public void resetTrackerOnScreenClose (CallbackInfo info) {
 		ScrollTracker.reset();
 	}
+
+    @Inject( method = "render", at = @At("HEAD"))
+    private void resetTooltipState(CallbackInfo info){
+        //set the state of tooltips to be false at the start of the render frame. If any tooltip is displayed during the render, it should be set to true from within DrawContextMixin.
+        ScrollTracker.setTooltipShown(false);
+    }
 }

--- a/src/main/resources/assets/toolscroll/lang/en_us.json
+++ b/src/main/resources/assets/toolscroll/lang/en_us.json
@@ -16,6 +16,7 @@
     "entry.tooltipscroll.scrollspeedkeys": "Keyboard Scrolling Speed",
     "entry.tooltipscroll.smoothness": "Scroll Smoothness",
     "entry.tooltipscroll.matrix_compatibility": "Matrix Compatibility",
+    "entry.tooltipscroll.disablechatscroll": "Disable Chat Scrolling",
 
     "entrytooltip.tooltipscroll.canscroll": "Allows the scroll wheel to move a tooltip.",
     "entrytooltip.tooltipscroll.usewasd": "Allows the WASD keys to move a tooltip.",
@@ -28,6 +29,7 @@
     "entrytooltip.tooltipscroll.scrollspeedkeys": "Tooltip speed when moving it with the keyboard.",
     "entrytooltip.tooltipscroll.smoothness": "How fast the tooltip should slide between positions.\nRange of [0.05 - 1], where 1 is instant.",
     "entrytooltip.tooltipscroll.matrix_compatibility": "Changes how Tooltip Scroll handles tooltips moving.\nMay improve compatibility with some mods.\nBreaks the start-on-top feature.",
+    "entrytooltip.tooltipscroll.disablechatscroll": "Disable scrolling chat while hovering a tooltip.",
 
     "key.tooltipscroll.moveUp": "Move Tooltip Up",
     "key.tooltipscroll.moveDown": "Move Tooltip Down",

--- a/src/main/resources/toolscroll.mixins.json
+++ b/src/main/resources/toolscroll.mixins.json
@@ -6,6 +6,7 @@
   "mixins": [
   ],
   "client": [
+    "ChatMixin",
     "DrawContextMixin",
     "MouseMixin",
     "KeyBindAccessor",


### PR DESCRIPTION
Added feature to disable scrolling the chat while a tooltip is hovered. This means you can view a tooltip hovered in the chat and scroll it without it leaving your mouse cursor and in turn closing the tooltip. The feature is disabled by default to maintain existing behavior.

**Summary of changes:**
- Added configuration option
- "tooltipShown" flag
  - Set flag at the start of render loop to false
  - If a tooltip is displayed during the render loop, set the flag to true
- When the chat is scrolled, cancel the event through a mixin if "tooltipShown" is true and the setting is enabled